### PR TITLE
Resolve symlinked current directory for LOCAL_PATH variable

### DIFF
--- a/sync-with-rclone.sh
+++ b/sync-with-rclone.sh
@@ -35,7 +35,7 @@ if [[ "$PREV_OPERATION" == "sync" ]]; then
     echo "Warning: OPERATION=sync from config/environment is ignored. Use the --sync flag to enable sync mode." >&2
 fi
 
-readonly LOCAL_PATH="." # Local project path (current directory)
+readonly LOCAL_PATH="$(pwd -P)" # Local project path (current directory, symlinks resolved)
 
 # Store script name as a relative path
 SCRIPT_NAME="$0"


### PR DESCRIPTION
When current directory `.` is directly a symlink, rclone `--link` will check `.` and see it as a link and want to create a `.rclonelink` file for it, and that will fail.

This update uses `pwd -P` as local instead of `.`, will not trigger the rclone bug.